### PR TITLE
Hello cairo 15 puzzle tuple v2 minimal

### DIFF
--- a/src/starkware/cairo/docs/hello_cairo/dict.rst
+++ b/src/starkware/cairo/docs/hello_cairo/dict.rst
@@ -322,7 +322,7 @@ and use ``--layout=small`` to ``cairo-run`` due to the usage of builtins):
         let (__fp__, _) = get_fp_and_pc()
         check_solution(
             loc_list=cast(&loc_tuple, Location*),
-            tile_list=&tiles,
+            tile_list=cast(&tiles, felt*),
             n_steps=4)
         return ()
     end


### PR DESCRIPTION
This is a simpler alternative to PR #27, and seeks to introduce tuples in a way that is less disruptive to the main functions. Tuples are used only for ``tile_list``, rather than both the ``tile_list`` and ``loc_list``.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/28)
<!-- Reviewable:end -->
