### PR TITLE
Use sys.executable before looking for Python in hardcoded paths

### DIFF
--- a/src/cmake_utils/gen_venv.py
+++ b/src/cmake_utils/gen_venv.py
@@ -79,13 +79,12 @@ def get_pth_dir(python: str, venv_dir: str):
         raise NotImplementedError(f"Unsupported python executable {python}")
 
 
-def find_python(exec_name):
+def find_python(exec_name: str) -> str:
     """
     Tries to find Python executable in well known paths.
 
-    :param exec_name: Expected name of the Python executable, for example `python3.7`.
-    :raises RuntimeError: if unable to find Python executable.
-    :return: Absolute path to found Python executable.
+    Arguments:
+    exec_name: Expected name of the Python executable, for example `python3.7`.
     """
 
     path = "/usr/bin:/usr/local/bin:" + os.getenv("PATH", default="")


### PR DESCRIPTION
This PR fixes build scripts to run in environments where Python is not installed globally. I expect this to be a rather frequent case due to the popularity of Python virtual environments and version managers such as ASDF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/46)
<!-- Reviewable:end -->
