### PR TITLE
Save common Black options in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 100
+target-version = ['py37']


### PR DESCRIPTION
I have been asked by @liorgold2  to format code with `black -l 100 -t py37`. I'm not a big fan of having to remember CLI options, so I propose to store these custom options in config file which Black understands. Not an urgent thing (I can gitignore this).

Black documentation: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#what-on-earth-is-a-pyproject-toml-file

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/48)
<!-- Reviewable:end -->
