### PR TITLE
Add CodeBlock.empty()

### DIFF
--- a/src/starkware/cairo/lang/compiler/ast/code_elements.py
+++ b/src/starkware/cairo/lang/compiler/ast/code_elements.py
@@ -423,6 +423,10 @@ class CodeBlock(AstNode):
         return CodeBlock(code_elements=self.code_elements + other.code_elements)
 
     @classmethod
+    def empty(cls):
+        return cls([])
+
+    @classmethod
     def from_code_elements(cls, code_elements: Iterable[CodeElement]) -> "CodeBlock":
         return cls(
             code_elements=[


### PR DESCRIPTION
This little class method makes it clear that we want an empty `CodeBlock`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/75)
<!-- Reviewable:end -->
