### PR TITLE
Add CodeElementConditionalJump

### DIFF
--- a/src/starkware/cairo/lang/compiler/ast/code_elements.py
+++ b/src/starkware/cairo/lang/compiler/ast/code_elements.py
@@ -54,6 +54,27 @@ class CodeElementInstruction(CodeElement):
 
 
 @dataclasses.dataclass
+class CodeElementConditionalJump(CodeElement):
+    """
+    Represents the instruction "jmp <label>" or "jmp <label> if <condition> != 0", where condition
+    is arbitrary expression.
+
+    Only constructible manually within compiler.
+    """
+
+    label: ExprIdentifier
+    condition: Optional[Expression]
+    location: Optional[Location] = LocationField
+
+    def format(self, allowed_line_length):
+        condition_str = "" if self.condition is None else f" if {self.condition.format()} != 0"
+        return f"jmp {self.label.format()}{condition_str}"
+
+    def get_children(self) -> Sequence[Optional[AstNode]]:
+        return [self.label, self.condition]
+
+
+@dataclasses.dataclass
 class CodeElementConst(CodeElement):
     identifier: ExprIdentifier
     expr: Expression


### PR DESCRIPTION
This is a spin off a JumpToLabelInstruction which allows any expressions to be passed as conditions, and `Preprocessor` simplifies the condition before emitting instructions using the same logic as used in `CodeElementIf`.

The goal is to be able to emit jumps with arbitrary expressions in early stages of compilation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/76)
<!-- Reviewable:end -->
