### PR TITLE
Add CodeElementEraseIfUnreachable

### DIFF
--- a/src/starkware/cairo/lang/compiler/ast/code_elements.py
+++ b/src/starkware/cairo/lang/compiler/ast/code_elements.py
@@ -744,6 +744,17 @@ class CodeElementAllocLocals(CodeElement):
         return []
 
 
+@dataclasses.dataclass
+class CodeElementEraseIfUnreachable(CodeElement):
+    code_element: CodeElement
+
+    def format(self, allowed_line_length):
+        return self.code_element.format(allowed_line_length)
+
+    def get_children(self) -> Sequence[Optional[AstNode]]:
+        return [self.code_element]
+
+
 def is_empty_line(code_element: CommentedCodeElement):
     return isinstance(code_element.code_elm, CodeElementEmptyLine) and code_element.comment is None
 

--- a/src/starkware/cairo/lang/compiler/ast/visitor.py
+++ b/src/starkware/cairo/lang/compiler/ast/visitor.py
@@ -1,9 +1,11 @@
+import dataclasses
 from contextlib import contextmanager
 from typing import List, Optional
 
 from starkware.cairo.lang.compiler.ast.code_elements import (
     CodeBlock,
     CodeElementDirective,
+    CodeElementEraseIfUnreachable,
     CodeElementFunction,
     CodeElementIf,
     CodeElementScoped,
@@ -105,6 +107,9 @@ class Visitor:
 
     def visit_CodeElementWith(self, elm: CodeElementWith):
         return CodeElementWith(identifiers=elm.identifiers, code_block=self.visit(elm.code_block))
+
+    def visit_CodeElementEraseIfUnreachable(self, elm: CodeElementEraseIfUnreachable):
+        return dataclasses.replace(elm, code_element=self.visit(elm.code_element))
 
     def _visit_default(self, obj):
         """

--- a/src/starkware/cairo/lang/compiler/preprocessor/preprocessor.py
+++ b/src/starkware/cairo/lang/compiler/preprocessor/preprocessor.py
@@ -27,6 +27,7 @@ from starkware.cairo.lang.compiler.ast.code_elements import (
     CodeElementConst,
     CodeElementDirective,
     CodeElementEmptyLine,
+    CodeElementEraseIfUnreachable,
     CodeElementFuncCall,
     CodeElementFunction,
     CodeElementHint,
@@ -1253,6 +1254,10 @@ Expected 'elm.element_type' to be a 'namespace'. Found: '{elm.element_type}'."""
             raise PreprocessorError(
                 f"Static assert failed: {a.format()} != {b.format()}.", location=elm.location
             )
+
+    def visit_CodeElementEraseIfUnreachable(self, elm: CodeElementEraseIfUnreachable):
+        if self.flow_tracking.data != FlowTrackingDataUnreachable():
+            self.visit(elm.code_element)
 
     def optimize_expressions_for_push(self, exprs: List[Expression]) -> List[Expression]:
         """


### PR DESCRIPTION
This little virtual `CodeElement` wrapper allows hinting the `Preprocessor` that it is totally fine to skip emitting instructions of wrapped code element if flow tracking states that it is unreachable.

`CodeElementIf` preprocessing method used this optimization in order to avoid emitting unreachable jumps, and the goal here is to externalize this behaviour, so that If lowering stage will be able to take advantage of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/77)
<!-- Reviewable:end -->
