### PR TITLE
Allow arbitrarily structured boolean expressions, add `first_bool_leaf` method, add `or` expression AST

### DIFF
--- a/src/starkware/cairo/lang/compiler/ast/bool_expr.py
+++ b/src/starkware/cairo/lang/compiler/ast/bool_expr.py
@@ -63,7 +63,7 @@ class BoolEqExpr(BoolExpr):
 @dataclasses.dataclass
 class BoolAndExpr(BoolExpr):
     """
-    Represents logical conjunction of two ``BoolExpr``s (``and`` operator).
+    Represents logical *and* of two ``BoolExpr``s (``and`` operator).
     """
 
     a: BoolExpr
@@ -89,7 +89,7 @@ class BoolAndExpr(BoolExpr):
 @dataclasses.dataclass
 class BoolOrExpr(BoolExpr):
     """
-    Represents logical alternative of two ``BoolExpr``s (``or`` operator).
+    Represents logical *or* of two ``BoolExpr``s (``or`` operator).
     """
 
     a: BoolExpr


### PR DESCRIPTION
This PR prepares the AST for the if-to-jumps lowering algorithm which will allow greater flexibility of boolean expressions.

Also added `BoolOrExpr` because in the if-to-jumps code handling these will be very trivial, but the syntax is not there yet and I plan to work on it later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/78)
<!-- Reviewable:end -->
