### PR TITLE
Scaffold generator lowering interface

### DIFF
--- a/src/starkware/cairo/lang/compiler/preprocessor/for_loop/clauses.py
+++ b/src/starkware/cairo/lang/compiler/preprocessor/for_loop/clauses.py
@@ -7,16 +7,22 @@ from starkware.cairo.lang.compiler.ast.for_loop import ForClauseIn
 from starkware.cairo.lang.compiler.ast.types import TypedIdentifier
 from starkware.cairo.lang.compiler.error_handling import Location
 from starkware.cairo.lang.compiler.preprocessor.for_loop.errors import ForLoopLoweringError
+from starkware.cairo.lang.compiler.preprocessor.for_loop.generators import GeneratorLowering
 
 
 @dataclasses.dataclass
 class InClauseLowering:
     iter_identifier: TypedIdentifier
     generator_location: Location
+    generator: GeneratorLowering
 
     @classmethod
     def from_clause(cls, clause: ForClauseIn) -> "InClauseLowering":
-        return cls(iter_identifier=clause.identifier, generator_location=clause.generator.location)
+        return cls(
+            iter_identifier=clause.identifier,
+            generator_location=clause.generator.location,
+            generator=GeneratorLowering.from_in_clause(clause),
+        )
 
 
 def fetch_in_clause(elm: CodeElementFor) -> ForClauseIn:

--- a/src/starkware/cairo/lang/compiler/preprocessor/for_loop/generators.py
+++ b/src/starkware/cairo/lang/compiler/preprocessor/for_loop/generators.py
@@ -1,0 +1,66 @@
+from abc import ABC, abstractmethod
+from typing import Tuple, List
+
+from starkware.cairo.lang.compiler.ast.bool_expr import BoolExpr
+from starkware.cairo.lang.compiler.ast.cairo_types import CairoType
+from starkware.cairo.lang.compiler.ast.code_elements import CodeBlock
+from starkware.cairo.lang.compiler.ast.expr import Expression, ExprIdentifier
+from starkware.cairo.lang.compiler.ast.for_loop import (
+    ForClauseIn,
+    ForGeneratorRange,
+    ForGeneratorSlice,
+)
+
+
+class GeneratorLowering(ABC):
+    @abstractmethod
+    def declare_iterator(self) -> List[CairoType]:
+        """
+        Provide Cairo types of all iterator variables.
+        """
+
+    @abstractmethod
+    def init_envelope_iterator(self) -> Tuple[CodeBlock, List[Expression]]:
+        """
+        Provide Cairo code which initializes iterator variables.
+        """
+
+    @abstractmethod
+    def condition(self, *iters: ExprIdentifier) -> Tuple[CodeBlock, BoolExpr]:
+        """
+        Provide Cairo code which checks if iteration reaches end.
+        """
+
+    @abstractmethod
+    def bind_iterator(self, *iters: ExprIdentifier) -> Expression:
+        """
+        Return Cairo expression which will bind source code surfacing iterator reference.
+        """
+
+    @abstractmethod
+    def increment_iterator(self, *iters: ExprIdentifier) -> Tuple[CodeBlock, List[Expression]]:
+        """
+        Provide Cairo code which increments iterator variables.
+        """
+
+    @staticmethod
+    def from_in_clause(clause: ForClauseIn) -> "GeneratorLowering":
+        # We are importing locally to prevent import cycles
+        # from starkware.cairo.lang.compiler.preprocessor.for_loop.range_generator import (
+        #     RangeGeneratorLowering,
+        # )
+        # from starkware.cairo.lang.compiler.preprocessor.for_loop.slice_generator import (
+        #     SliceGeneratorLowering,
+        # )
+
+        generator = clause.generator
+        if isinstance(generator, ForGeneratorRange):
+            # return RangeGeneratorLowering(generator)
+            return NotImplemented
+        elif isinstance(generator, ForGeneratorSlice):
+            # return SliceGeneratorLowering(generator)
+            return NotImplemented
+        else:
+            raise NotImplementedError(
+                f"Lowering '{generator.func_ident.name}' generator is not implemented yet."
+            )


### PR DESCRIPTION
In `GeneratorLowering.from_in_clause` there are commented out pieces of code with will be uncommented in subsequent PRs which will implement both generators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-docs/85)
<!-- Reviewable:end -->
